### PR TITLE
Replace @ prefix with $ for JSON-LD properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Then you can use it by importing `"schema-dts"`.
 
 ### Root context
 
-You will usually want your top-level item to include a `@context`, like
+You will usually want your top-level item to include a `$context`, like
 `https://schema.org`. In order for your object type to accept this property, you
 can augment it with `WithContext`, e.g.:
 
@@ -47,11 +47,11 @@ can augment it with `WithContext`, e.g.:
 import type {Person, WithContext} from 'schema-dts';
 
 const p: WithContext<Person> = {
-  '@context': 'https://schema.org',
-  '@type': 'Person',
+  $context: 'https://schema.org',
+  $type: 'Person',
   name: 'Eve',
   affiliation: {
-    '@type': 'School',
+    $type: 'School',
     name: 'Nice School',
   },
 };
@@ -59,59 +59,59 @@ const p: WithContext<Person> = {
 
 ### Graphs and IDs
 
-JSON-LD supports `'@graph'` objects that have richer interconnected links
+JSON-LD supports `'$graph'` objects that have richer interconnected links
 between the nodes. You can do that easily in `schema-dts` by using the `Graph`
 type.
 
-Notice that any node can have an `@id` when defining it. And you can reference
+Notice that any node can have an `$id` when defining it. And you can reference
 the same node from different places by simply using an ID stub, for example
-`{ '@id': 'https://my.site/about/#page }` below is an ID stub.
+`{ '$id': 'https://my.site/about/#page }` below is an ID stub.
 
 The example below shows potential JSON-LD for an About page. It includes
 definitions of Alyssa P. Hacker (the author & subject of the page), the specific
 page in this URL, and the website it belongs to. Some objects are still defined
 as inline nested objects (e.g. Occupation), since they are only referenced by
-their parent. Other objects are defined at the top-level with an `@id`, because
+their parent. Other objects are defined at the top-level with an `$id`, because
 multiple nodes refer to them.
 
 ```ts
 import type {Graph} from 'schema-dts';
 
 const graph: Graph = {
-  '@context': 'https://schema.org',
-  '@graph': [
+  $context: 'https://schema.org',
+  $graph: [
     {
-      '@type': 'Person',
-      '@id': 'https://my.site/#alyssa',
+      $type: 'Person',
+      $id: 'https://my.site/#alyssa',
       name: 'Alyssa P. Hacker',
       hasOccupation: {
-        '@type': 'Occupation',
+        $type: 'Occupation',
         name: 'LISP Hacker',
         qualifications: 'Knows LISP',
       },
-      mainEntityOfPage: {'@id': 'https://my.site/about/#page'},
-      subjectOf: {'@id': 'https://my.site/about/#page'},
+      mainEntityOfPage: {$id: 'https://my.site/about/#page'},
+      subjectOf: {$id: 'https://my.site/about/#page'},
     },
     {
-      '@type': 'AboutPage',
-      '@id': 'https://my.site/#site',
+      $type: 'AboutPage',
+      $id: 'https://my.site/#site',
       url: 'https://my.site',
       name: "Alyssa P. Hacker's Website",
       inLanguage: 'en-US',
       description: 'The personal website of LISP legend Alyssa P. Hacker',
-      mainEntity: {'@id': 'https://my.site/#alyssa'},
+      mainEntity: {$id: 'https://my.site/#alyssa'},
     },
     {
-      '@type': 'WebPage',
-      '@id': 'https://my.site/about/#page',
+      $type: 'WebPage',
+      $id: 'https://my.site/about/#page',
       url: 'https://my.site/about/',
       name: "About | Alyssa P. Hacker's Website",
       inLanguage: 'en-US',
       isPartOf: {
-        '@id': 'https://my.site/#site',
+        $id: 'https://my.site/#site',
       },
-      about: {'@id': 'https://my.site/#alyssa'},
-      mainEntity: {'@id': 'https://my.site/#alyssa'},
+      about: {$id: 'https://my.site/#alyssa'},
+      mainEntity: {$id: 'https://my.site/#alyssa'},
     },
   ],
 };
@@ -128,7 +128,7 @@ type you want to annotate. See the following examples:
 import type {SearchAction, WithActionConstraints} from 'schema-dts';
 
 const potentialAction: WithActionConstraints<SearchAction> = {
-  '@type': 'SearchAction',
+  $type: 'SearchAction',
   'query-input': 'required name=search_term_string',
   // ...
 };
@@ -138,9 +138,9 @@ const potentialAction: WithActionConstraints<SearchAction> = {
 import type {SearchAction, WebSite, WithActionConstraints} from 'schema-dts';
 
 const website: WebSite = {
-  '@type': 'WebSite',
+  $type: 'WebSite',
   potentialAction: {
-    '@type': 'SearchAction',
+    $type: 'SearchAction',
     'query-input': 'required name=search_term_string',
   } as WithActionConstraints<SearchAction>,
 };
@@ -165,13 +165,13 @@ Command line usage:
     specifying a top-level `Thing` type.
 
 - **`--context`**: Defaults to `https://schema.org`, the value or values to be
-  used with the `"@context"` property.
+  used with the `"$context"` property.
 
   Can be either a single URL, or a comma separated list of two or more name:URL
   pairs.
 
   The context affects names of string properties in types, as well as the values
-  of an object's `"@type"`.
+  of an object's `"$type"`.
 
 - **`--deprecated`**/**`--nodeprecated`**: Whether or not to include deprecated
   Schema.org types and properties. When included, these types will still be

--- a/package-lock.json
+++ b/package-lock.json
@@ -1319,6 +1319,10 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@mdxld/schema": {
+      "resolved": "packages/schema-dts",
+      "link": true
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -7512,10 +7516,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/schema-dts": {
-      "resolved": "packages/schema-dts",
-      "link": true
-    },
     "node_modules/schema-dts-gen": {
       "resolved": "packages/schema-dts-gen",
       "link": true
@@ -8765,6 +8765,7 @@
       }
     },
     "packages/schema-dts": {
+      "name": "@mdxld/schema",
       "version": "1.1.5",
       "license": "Apache-2.0",
       "devDependencies": {

--- a/packages/schema-dts-gen/src/ts/class.ts
+++ b/packages/schema-dts-gen/src/ts/class.ts
@@ -381,7 +381,7 @@ export class Class {
     // };
     // // Leaf:
     // export type XyzLeaf = XyzBase & {
-    //   '@type': 'Xyz'
+    //   '$type': 'Xyz'
     // }
     // // Complete Type ----------------------------//
     // export type Xyz = "Enum1"|"Enum2"|...        // Enum Piece: Optional.

--- a/packages/schema-dts-gen/src/ts/context.ts
+++ b/packages/schema-dts-gen/src/ts/context.ts
@@ -97,7 +97,7 @@ export class Context {
   contextProperty(): PropertySignature {
     return factory.createPropertySignature(
       /*modifiers=*/ [],
-      factory.createStringLiteral('@context'),
+      factory.createStringLiteral('$context'),
       /*questionToken=*/ undefined,
       this.typeNode(),
     );

--- a/packages/schema-dts-gen/src/ts/helper_types.ts
+++ b/packages/schema-dts-gen/src/ts/helper_types.ts
@@ -18,7 +18,7 @@ function IdPropertyNode() {
     'IRI identifying the canonical address of this object.',
     factory.createPropertySignature(
       /* modifiers= */ [],
-      factory.createStringLiteral('@id'),
+      factory.createStringLiteral('$id'),
       /* questionToken= */ undefined,
       /* typeNode= */
       factory.createTypeReferenceNode('string', /*typeArguments=*/ []),
@@ -65,7 +65,7 @@ function GraphType(context: Context) {
         context.contextProperty(),
         factory.createPropertySignature(
           /*modifiers=*/ [],
-          factory.createStringLiteral('@graph'),
+          factory.createStringLiteral('$graph'),
           /*questionToken=*/ undefined,
           factory.createTypeOperatorNode(
             SyntaxKind.ReadonlyKeyword,

--- a/packages/schema-dts-gen/src/ts/property.ts
+++ b/packages/schema-dts-gen/src/ts/property.ts
@@ -169,7 +169,7 @@ export class TypeProperty {
   toNode(context: Context) {
     return factory.createPropertySignature(
       /* modifiers= */ [],
-      factory.createStringLiteral('@type'),
+      factory.createStringLiteral('$type'),
       /* questionToken= */ undefined,
       /* typeNode= */
       factory.createTypeReferenceNode(

--- a/packages/schema-dts-gen/test/baselines/category_test.ts
+++ b/packages/schema-dts-gen/test/baselines/category_test.ts
@@ -47,16 +47,16 @@ test(`baseline_${basename(import.meta.url)}`, async () => {
   expect(actual).toMatchInlineSnapshot(`
 "/** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
 export type WithContext<T extends Thing> = T & {
-    "@context": "https://schema.org";
+    "$context": "https://schema.org";
 };
 export interface Graph {
-    "@context": "https://schema.org";
-    "@graph": readonly Thing[];
+    "$context": "https://schema.org";
+    "$graph": readonly Thing[];
 }
 type SchemaValue<T> = T | readonly T[];
 type IdReference = {
     /** IRI identifying the canonical address of this object. */
-    "@id": string;
+    "$id": string;
 };
 type InputActionConstraints<T extends ActionBase> = Partial<{
     [K in Exclude<keyof T, \`@\${string}\`> as \`\${string & K}-input\`]: PropertyValueSpecification | string;
@@ -70,7 +70,7 @@ export type WithActionConstraints<T extends ActionBase> = T & InputActionConstra
 export type Text = string;
 
 interface DistilleryLeaf extends ThingBase {
-    "@type": "Distillery";
+    "$type": "Distillery";
 }
 /** A distillery. */
 export type Distillery = DistilleryLeaf;
@@ -79,7 +79,7 @@ interface ThingBase extends Partial<IdReference> {
     "name"?: SchemaValue<Text>;
 }
 interface ThingLeaf extends ThingBase {
-    "@type": "Thing";
+    "$type": "Thing";
 }
 export type Thing = ThingLeaf | Distillery;
 

--- a/packages/schema-dts-gen/test/baselines/comments_test.ts
+++ b/packages/schema-dts-gen/test/baselines/comments_test.ts
@@ -67,16 +67,16 @@ test(`baseline_${basename(import.meta.url)}`, async () => {
   expect(actual).toMatchInlineSnapshot(`
 "/** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
 export type WithContext<T extends Thing> = T & {
-    "@context": "https://schema.org";
+    "$context": "https://schema.org";
 };
 export interface Graph {
-    "@context": "https://schema.org";
-    "@graph": readonly Thing[];
+    "$context": "https://schema.org";
+    "$graph": readonly Thing[];
 }
 type SchemaValue<T> = T | readonly T[];
 type IdReference = {
     /** IRI identifying the canonical address of this object. */
-    "@id": string;
+    "$id": string;
 };
 type InputActionConstraints<T extends ActionBase> = Partial<{
     [K in Exclude<keyof T, \`@\${string}\`> as \`\${string & K}-input\`]: PropertyValueSpecification | string;
@@ -143,7 +143,7 @@ interface ThingBase extends Partial<IdReference> {
     "openingHours"?: SchemaValue<Text>;
 }
 interface ThingLeaf extends ThingBase {
-    "@type": "Thing";
+    "$type": "Thing";
 }
 /**
  * Things are amazing!

--- a/packages/schema-dts-gen/test/baselines/data_type_union_test.ts
+++ b/packages/schema-dts-gen/test/baselines/data_type_union_test.ts
@@ -45,16 +45,16 @@ test(`baseline_${basename(import.meta.url)}`, async () => {
   expect(actual).toMatchInlineSnapshot(`
 "/** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
 export type WithContext<T extends Thing> = T & {
-    "@context": "https://schema.org";
+    "$context": "https://schema.org";
 };
 export interface Graph {
-    "@context": "https://schema.org";
-    "@graph": readonly Thing[];
+    "$context": "https://schema.org";
+    "$graph": readonly Thing[];
 }
 type SchemaValue<T> = T | readonly T[];
 type IdReference = {
     /** IRI identifying the canonical address of this object. */
-    "@id": string;
+    "$id": string;
 };
 type InputActionConstraints<T extends ActionBase> = Partial<{
     [K in Exclude<keyof T, \`@\${string}\`> as \`\${string & K}-input\`]: PropertyValueSpecification | string;
@@ -77,7 +77,7 @@ interface ThingBase extends Partial<IdReference> {
     "name"?: SchemaValue<Text>;
 }
 interface ThingLeaf extends ThingBase {
-    "@type": "Thing";
+    "$type": "Thing";
 }
 export type Thing = ThingLeaf;
 

--- a/packages/schema-dts-gen/test/baselines/default_ontology_test.ts
+++ b/packages/schema-dts-gen/test/baselines/default_ontology_test.ts
@@ -32,16 +32,16 @@ test(`baseline_${basename(import.meta.url)}`, async () => {
   expect(actual).toMatchInlineSnapshot(`
 "/** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
 export type WithContext<T extends Thing> = T & {
-    "@context": "https://schema.org";
+    "$context": "https://schema.org";
 };
 export interface Graph {
-    "@context": "https://schema.org";
-    "@graph": readonly Thing[];
+    "$context": "https://schema.org";
+    "$graph": readonly Thing[];
 }
 type SchemaValue<T> = T | readonly T[];
 type IdReference = {
     /** IRI identifying the canonical address of this object. */
-    "@id": string;
+    "$id": string;
 };
 type InputActionConstraints<T extends ActionBase> = Partial<{
     [K in Exclude<keyof T, \`@\${string}\`> as \`\${string & K}-input\`]: PropertyValueSpecification | string;
@@ -55,7 +55,7 @@ export type WithActionConstraints<T extends ActionBase> = T & InputActionConstra
 interface ThingBase extends Partial<IdReference> {
 }
 interface ThingLeaf extends ThingBase {
-    "@type": "Thing";
+    "$type": "Thing";
 }
 export type Thing = ThingLeaf;
 

--- a/packages/schema-dts-gen/test/baselines/deprecated_objects_test.ts
+++ b/packages/schema-dts-gen/test/baselines/deprecated_objects_test.ts
@@ -68,16 +68,16 @@ test(`baseline_${basename(import.meta.url)}`, async () => {
   expect(actual).toMatchInlineSnapshot(`
 "/** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
 export type WithContext<T extends Thing> = T & {
-    "@context": "https://schema.org";
+    "$context": "https://schema.org";
 };
 export interface Graph {
-    "@context": "https://schema.org";
-    "@graph": readonly Thing[];
+    "$context": "https://schema.org";
+    "$graph": readonly Thing[];
 }
 type SchemaValue<T> = T | readonly T[];
 type IdReference = {
     /** IRI identifying the canonical address of this object. */
-    "@id": string;
+    "$id": string;
 };
 type InputActionConstraints<T extends ActionBase> = Partial<{
     [K in Exclude<keyof T, \`@\${string}\`> as \`\${string & K}-input\`]: PropertyValueSpecification | string;
@@ -96,7 +96,7 @@ interface CarBase extends ThingBase {
     "doorNumber"?: SchemaValue<Number>;
 }
 interface CarLeaf extends CarBase {
-    "@type": "Car";
+    "$type": "Car";
 }
 export type Car = CarLeaf;
 
@@ -104,7 +104,7 @@ interface PersonLikeBase extends ThingBase {
     "height"?: SchemaValue<Number>;
 }
 interface PersonLikeLeaf extends PersonLikeBase {
-    "@type": "PersonLike";
+    "$type": "PersonLike";
 }
 export type PersonLike = PersonLikeLeaf;
 
@@ -125,7 +125,7 @@ interface ThingBase extends Partial<IdReference> {
     "names2"?: SchemaValue<Text>;
 }
 interface ThingLeaf extends ThingBase {
-    "@type": "Thing";
+    "$type": "Thing";
 }
 export type Thing = ThingLeaf | Car | PersonLike | Vehicle;
 
@@ -135,7 +135,7 @@ interface VehicleBase extends ThingBase {
     "doors"?: SchemaValue<Number>;
 }
 interface VehicleLeaf extends VehicleBase {
-    "@type": "Vehicle";
+    "$type": "Vehicle";
 }
 /** @deprecated Use Car instead. */
 export type Vehicle = VehicleLeaf;

--- a/packages/schema-dts-gen/test/baselines/duplicate_comments_test.ts
+++ b/packages/schema-dts-gen/test/baselines/duplicate_comments_test.ts
@@ -49,16 +49,16 @@ test(`baseline_${basename(import.meta.url)}`, async () => {
   expect(actual).toMatchInlineSnapshot(`
 "/** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
 export type WithContext<T extends Thing> = T & {
-    "@context": "https://schema.org";
+    "$context": "https://schema.org";
 };
 export interface Graph {
-    "@context": "https://schema.org";
-    "@graph": readonly Thing[];
+    "$context": "https://schema.org";
+    "$graph": readonly Thing[];
 }
 type SchemaValue<T> = T | readonly T[];
 type IdReference = {
     /** IRI identifying the canonical address of this object. */
-    "@id": string;
+    "$id": string;
 };
 type InputActionConstraints<T extends ActionBase> = Partial<{
     [K in Exclude<keyof T, \`@\${string}\`> as \`\${string & K}-input\`]: PropertyValueSpecification | string;
@@ -79,7 +79,7 @@ interface ThingBase extends Partial<IdReference> {
     "name"?: SchemaValue<Text>;
 }
 interface ThingLeaf extends ThingBase {
-    "@type": "Thing";
+    "$type": "Thing";
 }
 /**
  * Things are amazing!

--- a/packages/schema-dts-gen/test/baselines/enum_skipped_test.ts
+++ b/packages/schema-dts-gen/test/baselines/enum_skipped_test.ts
@@ -45,16 +45,16 @@ test(`baseline_${basename(import.meta.url)}`, async () => {
   expect(actual).toMatchInlineSnapshot(`
 "/** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
 export type WithContext<T extends Thing> = T & {
-    "@context": "https://schema.org";
+    "$context": "https://schema.org";
 };
 export interface Graph {
-    "@context": "https://schema.org";
-    "@graph": readonly Thing[];
+    "$context": "https://schema.org";
+    "$graph": readonly Thing[];
 }
 type SchemaValue<T> = T | readonly T[];
 type IdReference = {
     /** IRI identifying the canonical address of this object. */
-    "@id": string;
+    "$id": string;
 };
 type InputActionConstraints<T extends ActionBase> = Partial<{
     [K in Exclude<keyof T, \`@\${string}\`> as \`\${string & K}-input\`]: PropertyValueSpecification | string;
@@ -68,7 +68,7 @@ export type WithActionConstraints<T extends ActionBase> = T & InputActionConstra
 interface ThingBase extends Partial<IdReference> {
 }
 interface ThingLeaf extends ThingBase {
-    "@type": "Thing";
+    "$type": "Thing";
 }
 /** A Thing! */
 export type Thing = "http://schema.org/a" | "https://schema.org/a" | "a" | "http://schema.org/b" | "https://schema.org/b" | "b" | "http://schema.org/c" | "https://schema.org/c" | "c" | "http://schema.org/d" | "https://schema.org/d" | "d" | "https://schema.org/e" | "e" | "http://google.com/f" | "https://google.com/f" | ThingLeaf;

--- a/packages/schema-dts-gen/test/baselines/inheritance_multiple_test.ts
+++ b/packages/schema-dts-gen/test/baselines/inheritance_multiple_test.ts
@@ -49,16 +49,16 @@ test(`baseline_${basename(import.meta.url)}`, async () => {
   expect(actual).toMatchInlineSnapshot(`
 "/** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
 export type WithContext<T extends Thing> = T & {
-    "@context": "https://schema.org";
+    "$context": "https://schema.org";
 };
 export interface Graph {
-    "@context": "https://schema.org";
-    "@graph": readonly Thing[];
+    "$context": "https://schema.org";
+    "$graph": readonly Thing[];
 }
 type SchemaValue<T> = T | readonly T[];
 type IdReference = {
     /** IRI identifying the canonical address of this object. */
-    "@id": string;
+    "$id": string;
 };
 type InputActionConstraints<T extends ActionBase> = Partial<{
     [K in Exclude<keyof T, \`@\${string}\`> as \`\${string & K}-input\`]: PropertyValueSpecification | string;
@@ -77,7 +77,7 @@ interface PersonLikeBase extends ThingBase {
     "height"?: SchemaValue<Number>;
 }
 interface PersonLikeLeaf extends PersonLikeBase {
-    "@type": "PersonLike";
+    "$type": "PersonLike";
 }
 export type PersonLike = PersonLikeLeaf;
 
@@ -85,7 +85,7 @@ interface ThingBase extends Partial<IdReference> {
     "name"?: SchemaValue<Text>;
 }
 interface ThingLeaf extends ThingBase {
-    "@type": "Thing";
+    "$type": "Thing";
 }
 export type Thing = ThingLeaf | PersonLike | Vehicle;
 
@@ -93,7 +93,7 @@ interface VehicleBase extends ThingBase {
     "doors"?: SchemaValue<Number>;
 }
 interface VehicleLeaf extends VehicleBase {
-    "@type": "Vehicle";
+    "$type": "Vehicle";
 }
 export type Vehicle = VehicleLeaf;
 

--- a/packages/schema-dts-gen/test/baselines/inheritance_one_test.ts
+++ b/packages/schema-dts-gen/test/baselines/inheritance_one_test.ts
@@ -44,16 +44,16 @@ test(`baseline_${basename(import.meta.url)}`, async () => {
   expect(actual).toMatchInlineSnapshot(`
 "/** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
 export type WithContext<T extends Thing> = T & {
-    "@context": "https://schema.org";
+    "$context": "https://schema.org";
 };
 export interface Graph {
-    "@context": "https://schema.org";
-    "@graph": readonly Thing[];
+    "$context": "https://schema.org";
+    "$graph": readonly Thing[];
 }
 type SchemaValue<T> = T | readonly T[];
 type IdReference = {
     /** IRI identifying the canonical address of this object. */
-    "@id": string;
+    "$id": string;
 };
 type InputActionConstraints<T extends ActionBase> = Partial<{
     [K in Exclude<keyof T, \`@\${string}\`> as \`\${string & K}-input\`]: PropertyValueSpecification | string;
@@ -72,7 +72,7 @@ interface PersonLikeBase extends ThingBase {
     "height"?: SchemaValue<Number>;
 }
 interface PersonLikeLeaf extends PersonLikeBase {
-    "@type": "PersonLike";
+    "$type": "PersonLike";
 }
 export type PersonLike = PersonLikeLeaf;
 
@@ -80,7 +80,7 @@ interface ThingBase extends Partial<IdReference> {
     "name"?: SchemaValue<Text>;
 }
 interface ThingLeaf extends ThingBase {
-    "@type": "Thing";
+    "$type": "Thing";
 }
 export type Thing = ThingLeaf | PersonLike;
 

--- a/packages/schema-dts-gen/test/baselines/nested_datatype_test.ts
+++ b/packages/schema-dts-gen/test/baselines/nested_datatype_test.ts
@@ -59,16 +59,16 @@ test(`baseline_${basename(import.meta.url)}`, async () => {
   expect(actual).toMatchInlineSnapshot(`
 "/** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
 export type WithContext<T extends Thing> = T & {
-    "@context": "https://schema.org";
+    "$context": "https://schema.org";
 };
 export interface Graph {
-    "@context": "https://schema.org";
-    "@graph": readonly Thing[];
+    "$context": "https://schema.org";
+    "$graph": readonly Thing[];
 }
 type SchemaValue<T> = T | readonly T[];
 type IdReference = {
     /** IRI identifying the canonical address of this object. */
-    "@id": string;
+    "$id": string;
 };
 type InputActionConstraints<T extends ActionBase> = Partial<{
     [K in Exclude<keyof T, \`@\${string}\`> as \`\${string & K}-input\`]: PropertyValueSpecification | string;
@@ -85,12 +85,12 @@ interface ArabicTextBase extends PronounceableTextBase {
     "arabicPhoneticText"?: SchemaValue<Text>;
 }
 interface ArabicTextLeaf extends ArabicTextBase {
-    "@type": "ArabicText";
+    "$type": "ArabicText";
 }
 export type ArabicText = ArabicTextLeaf | string;
 
 interface EnglishTextLeaf extends PronounceableTextBase {
-    "@type": "EnglishText";
+    "$type": "EnglishText";
 }
 export type EnglishText = EnglishTextLeaf | string;
 
@@ -100,7 +100,7 @@ interface PronounceableTextBase extends Partial<IdReference> {
     "phoneticText"?: SchemaValue<Text>;
 }
 interface PronounceableTextLeaf extends PronounceableTextBase {
-    "@type": "PronounceableText";
+    "$type": "PronounceableText";
 }
 export type PronounceableText = PronounceableTextLeaf | ArabicText | EnglishText | string;
 
@@ -110,7 +110,7 @@ interface ThingBase extends Partial<IdReference> {
     "website"?: SchemaValue<URL>;
 }
 interface ThingLeaf extends ThingBase {
-    "@type": "Thing";
+    "$type": "Thing";
 }
 export type Thing = ThingLeaf;
 

--- a/packages/schema-dts-gen/test/baselines/nodeprecated_objects_test.ts
+++ b/packages/schema-dts-gen/test/baselines/nodeprecated_objects_test.ts
@@ -67,16 +67,16 @@ test(`baseline_${basename(import.meta.url)}`, async () => {
   expect(actual).toMatchInlineSnapshot(`
 "/** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
 export type WithContext<T extends Thing> = T & {
-    "@context": "https://schema.org";
+    "$context": "https://schema.org";
 };
 export interface Graph {
-    "@context": "https://schema.org";
-    "@graph": readonly Thing[];
+    "$context": "https://schema.org";
+    "$graph": readonly Thing[];
 }
 type SchemaValue<T> = T | readonly T[];
 type IdReference = {
     /** IRI identifying the canonical address of this object. */
-    "@id": string;
+    "$id": string;
 };
 type InputActionConstraints<T extends ActionBase> = Partial<{
     [K in Exclude<keyof T, \`@\${string}\`> as \`\${string & K}-input\`]: PropertyValueSpecification | string;
@@ -95,7 +95,7 @@ interface CarBase extends ThingBase {
     "doorNumber"?: SchemaValue<Number>;
 }
 interface CarLeaf extends CarBase {
-    "@type": "Car";
+    "$type": "Car";
 }
 export type Car = CarLeaf;
 
@@ -103,7 +103,7 @@ interface PersonLikeBase extends ThingBase {
     "height"?: SchemaValue<Number>;
 }
 interface PersonLikeLeaf extends PersonLikeBase {
-    "@type": "PersonLike";
+    "$type": "PersonLike";
 }
 export type PersonLike = PersonLikeLeaf;
 
@@ -111,7 +111,7 @@ interface ThingBase extends Partial<IdReference> {
     "name"?: SchemaValue<Text>;
 }
 interface ThingLeaf extends ThingBase {
-    "@type": "Thing";
+    "$type": "Thing";
 }
 export type Thing = ThingLeaf | Car | PersonLike;
 

--- a/packages/schema-dts-gen/test/baselines/owl_mixed_basic_test.ts
+++ b/packages/schema-dts-gen/test/baselines/owl_mixed_basic_test.ts
@@ -43,16 +43,16 @@ test(`baseline_mixedOWL1_${basename(import.meta.url)}`, async () => {
   expect(actual).toMatchInlineSnapshot(`
 "/** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
 export type WithContext<T extends Thing> = T & {
-    "@context": "https://schema.org";
+    "$context": "https://schema.org";
 };
 export interface Graph {
-    "@context": "https://schema.org";
-    "@graph": readonly Thing[];
+    "$context": "https://schema.org";
+    "$graph": readonly Thing[];
 }
 type SchemaValue<T> = T | readonly T[];
 type IdReference = {
     /** IRI identifying the canonical address of this object. */
-    "@id": string;
+    "$id": string;
 };
 type InputActionConstraints<T extends ActionBase> = Partial<{
     [K in Exclude<keyof T, \`@\${string}\`> as \`\${string & K}-input\`]: PropertyValueSpecification | string;
@@ -67,7 +67,7 @@ export type WithActionConstraints<T extends ActionBase> = T & InputActionConstra
 export type Text = string;
 
 interface PersonLeaf extends ThingBase {
-    "@type": "Person";
+    "$type": "Person";
 }
 /** ABC */
 export type Person = PersonLeaf | string;
@@ -76,7 +76,7 @@ interface ThingBase extends Partial<IdReference> {
     "name"?: SchemaValue<Text>;
 }
 interface ThingLeaf extends ThingBase {
-    "@type": "Thing";
+    "$type": "Thing";
 }
 /** ABC */
 export type Thing = ThingLeaf | Person;
@@ -108,16 +108,16 @@ test(`baseline_mixedOWL2_${basename(import.meta.url)}`, async () => {
   expect(actual).toMatchInlineSnapshot(`
 "/** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
 export type WithContext<T extends Thing> = T & {
-    "@context": "https://schema.org";
+    "$context": "https://schema.org";
 };
 export interface Graph {
-    "@context": "https://schema.org";
-    "@graph": readonly Thing[];
+    "$context": "https://schema.org";
+    "$graph": readonly Thing[];
 }
 type SchemaValue<T> = T | readonly T[];
 type IdReference = {
     /** IRI identifying the canonical address of this object. */
-    "@id": string;
+    "$id": string;
 };
 type InputActionConstraints<T extends ActionBase> = Partial<{
     [K in Exclude<keyof T, \`@\${string}\`> as \`\${string & K}-input\`]: PropertyValueSpecification | string;
@@ -132,7 +132,7 @@ export type WithActionConstraints<T extends ActionBase> = T & InputActionConstra
 export type Text = string;
 
 interface PersonLeaf extends ThingBase {
-    "@type": "Person";
+    "$type": "Person";
 }
 /** ABC */
 export type Person = PersonLeaf | string;
@@ -141,7 +141,7 @@ interface ThingBase extends Partial<IdReference> {
     "name"?: SchemaValue<Text>;
 }
 interface ThingLeaf extends ThingBase {
-    "@type": "Thing";
+    "$type": "Thing";
 }
 /** ABC */
 export type Thing = ThingLeaf | Person;
@@ -178,16 +178,16 @@ test(`baseline_OWLenum_${basename(import.meta.url)}`, async () => {
   expect(actual).toMatchInlineSnapshot(`
 "/** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
 export type WithContext<T extends Thing> = T & {
-    "@context": "https://schema.org";
+    "$context": "https://schema.org";
 };
 export interface Graph {
-    "@context": "https://schema.org";
-    "@graph": readonly Thing[];
+    "$context": "https://schema.org";
+    "$graph": readonly Thing[];
 }
 type SchemaValue<T> = T | readonly T[];
 type IdReference = {
     /** IRI identifying the canonical address of this object. */
-    "@id": string;
+    "$id": string;
 };
 type InputActionConstraints<T extends ActionBase> = Partial<{
     [K in Exclude<keyof T, \`@\${string}\`> as \`\${string & K}-input\`]: PropertyValueSpecification | string;
@@ -204,12 +204,12 @@ export type Text = string;
 interface MyEnumBase extends Partial<IdReference> {
 }
 interface MyEnumLeaf extends MyEnumBase {
-    "@type": "http://www.w3.org/2002/07/owl#MyEnum";
+    "$type": "http://www.w3.org/2002/07/owl#MyEnum";
 }
 export type MyEnum = "http://www.w3.org/2002/07/owl#EnumValueA" | "https://www.w3.org/2002/07/owl#EnumValueA" | "http://www.w3.org/2002/07/owl#EnumValueB" | "https://www.w3.org/2002/07/owl#EnumValueB" | MyEnumLeaf;
 
 interface PersonLeaf extends ThingBase {
-    "@type": "Person";
+    "$type": "Person";
 }
 /** ABC */
 export type Person = PersonLeaf | string;
@@ -218,7 +218,7 @@ interface ThingBase extends Partial<IdReference> {
     "name"?: SchemaValue<Text>;
 }
 interface ThingLeaf extends ThingBase {
-    "@type": "Thing";
+    "$type": "Thing";
 }
 /** ABC */
 export type Thing = ThingLeaf | Person;

--- a/packages/schema-dts-gen/test/baselines/property_edge_cases_test.ts
+++ b/packages/schema-dts-gen/test/baselines/property_edge_cases_test.ts
@@ -44,16 +44,16 @@ test(`baseline_${basename(import.meta.url)}`, async () => {
   expect(actual).toMatchInlineSnapshot(`
 "/** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
 export type WithContext<T extends Thing> = T & {
-    "@context": "https://schema.org";
+    "$context": "https://schema.org";
 };
 export interface Graph {
-    "@context": "https://schema.org";
-    "@graph": readonly Thing[];
+    "$context": "https://schema.org";
+    "$graph": readonly Thing[];
 }
 type SchemaValue<T> = T | readonly T[];
 type IdReference = {
     /** IRI identifying the canonical address of this object. */
-    "@id": string;
+    "$id": string;
 };
 type InputActionConstraints<T extends ActionBase> = Partial<{
     [K in Exclude<keyof T, \`@\${string}\`> as \`\${string & K}-input\`]: PropertyValueSpecification | string;
@@ -71,7 +71,7 @@ interface ThingBase extends Partial<IdReference> {
     "name"?: SchemaValue<Text>;
 }
 interface ThingLeaf extends ThingBase {
-    "@type": "Thing";
+    "$type": "Thing";
 }
 export type Thing = ThingLeaf;
 

--- a/packages/schema-dts-gen/test/baselines/quantities_test.ts
+++ b/packages/schema-dts-gen/test/baselines/quantities_test.ts
@@ -51,16 +51,16 @@ test(`baseline_${basename(import.meta.url)}`, async () => {
   expect(actual).toMatchInlineSnapshot(`
 "/** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
 export type WithContext<T extends Thing> = T & {
-    "@context": "https://schema.org";
+    "$context": "https://schema.org";
 };
 export interface Graph {
-    "@context": "https://schema.org";
-    "@graph": readonly Thing[];
+    "$context": "https://schema.org";
+    "$graph": readonly Thing[];
 }
 type SchemaValue<T> = T | readonly T[];
 type IdReference = {
     /** IRI identifying the canonical address of this object. */
-    "@id": string;
+    "$id": string;
 };
 type InputActionConstraints<T extends ActionBase> = Partial<{
     [K in Exclude<keyof T, \`@\${string}\`> as \`\${string & K}-input\`]: PropertyValueSpecification | string;
@@ -74,32 +74,32 @@ export type WithActionConstraints<T extends ActionBase> = T & InputActionConstra
 export type Text = string;
 
 interface DistanceLeaf extends ThingBase {
-    "@type": "Distance";
+    "$type": "Distance";
 }
 export type Distance = DistanceLeaf | string;
 
 interface DurationLeaf extends ThingBase {
-    "@type": "Duration";
+    "$type": "Duration";
 }
 export type Duration = DurationLeaf | string;
 
 interface EnergyLeaf extends ThingBase {
-    "@type": "Energy";
+    "$type": "Energy";
 }
 export type Energy = EnergyLeaf | string;
 
 interface IntangibleLeaf extends ThingBase {
-    "@type": "Intangible";
+    "$type": "Intangible";
 }
 export type Intangible = IntangibleLeaf | Quantity;
 
 interface MassLeaf extends ThingBase {
-    "@type": "Mass";
+    "$type": "Mass";
 }
 export type Mass = MassLeaf | string;
 
 interface QuantityLeaf extends ThingBase {
-    "@type": "Quantity";
+    "$type": "Quantity";
 }
 export type Quantity = QuantityLeaf | Distance | Duration | Energy | Mass | string;
 
@@ -107,7 +107,7 @@ interface ThingBase extends Partial<IdReference> {
     "name"?: SchemaValue<Text>;
 }
 interface ThingLeaf extends ThingBase {
-    "@type": "Thing";
+    "$type": "Thing";
 }
 export type Thing = ThingLeaf | Intangible;
 

--- a/packages/schema-dts-gen/test/baselines/role_inheritance_test.ts
+++ b/packages/schema-dts-gen/test/baselines/role_inheritance_test.ts
@@ -51,16 +51,16 @@ test(`baseline_${basename(import.meta.url)}`, async () => {
   expect(actual).toMatchInlineSnapshot(`
 "/** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
 export type WithContext<T extends Thing> = T & {
-    "@context": "https://schema.org";
+    "$context": "https://schema.org";
 };
 export interface Graph {
-    "@context": "https://schema.org";
-    "@graph": readonly Thing[];
+    "$context": "https://schema.org";
+    "$graph": readonly Thing[];
 }
 type SchemaValue<T, TProperty extends string> = T | Role<T, TProperty> | readonly (T | Role<T, TProperty>)[];
 type IdReference = {
     /** IRI identifying the canonical address of this object. */
-    "@id": string;
+    "$id": string;
 };
 type InputActionConstraints<T extends ActionBase> = Partial<{
     [K in Exclude<keyof T, \`@\${string}\`> as \`\${string & K}-input\`]: PropertyValueSpecification | string;
@@ -74,12 +74,12 @@ export type WithActionConstraints<T extends ActionBase> = T & InputActionConstra
 interface DateTimeBase extends Partial<IdReference> {
 }
 interface DateTimeLeaf extends DateTimeBase {
-    "@type": "DateTime";
+    "$type": "DateTime";
 }
 export type DateTime = DateTimeLeaf | string;
 
 type OrganizationRoleLeaf<TContent, TProperty extends string> = RoleBase & {
-    "@type": "OrganizationRole";
+    "$type": "OrganizationRole";
 } & {
     [key in TProperty]: TContent;
 };
@@ -89,7 +89,7 @@ interface RoleBase extends ThingBase {
     "startDate"?: SchemaValue<DateTime | IdReference, "startDate">;
 }
 type RoleLeaf<TContent, TProperty extends string> = RoleBase & {
-    "@type": "Role";
+    "$type": "Role";
 } & {
     [key in TProperty]: TContent;
 };
@@ -103,7 +103,7 @@ export type Role<TContent = never, TProperty extends string = never> = RoleLeaf<
 export type Text = string;
 
 interface IntangibleLeaf extends ThingBase {
-    "@type": "Intangible";
+    "$type": "Intangible";
 }
 export type Intangible = IntangibleLeaf | Role;
 
@@ -111,7 +111,7 @@ interface ThingBase extends Partial<IdReference> {
     "name"?: SchemaValue<Text, "name">;
 }
 interface ThingLeaf extends ThingBase {
-    "@type": "Thing";
+    "$type": "Thing";
 }
 export type Thing = ThingLeaf | Intangible;
 

--- a/packages/schema-dts-gen/test/baselines/role_simple_test.ts
+++ b/packages/schema-dts-gen/test/baselines/role_simple_test.ts
@@ -48,16 +48,16 @@ test(`baseline_${basename(import.meta.url)}`, async () => {
   expect(actual).toMatchInlineSnapshot(`
 "/** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
 export type WithContext<T extends Thing> = T & {
-    "@context": "https://schema.org";
+    "$context": "https://schema.org";
 };
 export interface Graph {
-    "@context": "https://schema.org";
-    "@graph": readonly Thing[];
+    "$context": "https://schema.org";
+    "$graph": readonly Thing[];
 }
 type SchemaValue<T, TProperty extends string> = T | Role<T, TProperty> | readonly (T | Role<T, TProperty>)[];
 type IdReference = {
     /** IRI identifying the canonical address of this object. */
-    "@id": string;
+    "$id": string;
 };
 type InputActionConstraints<T extends ActionBase> = Partial<{
     [K in Exclude<keyof T, \`@\${string}\`> as \`\${string & K}-input\`]: PropertyValueSpecification | string;
@@ -71,7 +71,7 @@ export type WithActionConstraints<T extends ActionBase> = T & InputActionConstra
 interface DateTimeBase extends Partial<IdReference> {
 }
 interface DateTimeLeaf extends DateTimeBase {
-    "@type": "DateTime";
+    "$type": "DateTime";
 }
 export type DateTime = DateTimeLeaf | string;
 
@@ -79,7 +79,7 @@ interface RoleBase extends ThingBase {
     "startDate"?: SchemaValue<DateTime | IdReference, "startDate">;
 }
 type RoleLeaf<TContent, TProperty extends string> = RoleBase & {
-    "@type": "Role";
+    "$type": "Role";
 } & {
     [key in TProperty]: TContent;
 };
@@ -93,7 +93,7 @@ export type Role<TContent = never, TProperty extends string = never> = RoleLeaf<
 export type Text = string;
 
 interface IntangibleLeaf extends ThingBase {
-    "@type": "Intangible";
+    "$type": "Intangible";
 }
 export type Intangible = IntangibleLeaf | Role;
 
@@ -101,7 +101,7 @@ interface ThingBase extends Partial<IdReference> {
     "name"?: SchemaValue<Text, "name">;
 }
 interface ThingLeaf extends ThingBase {
-    "@type": "Thing";
+    "$type": "Thing";
 }
 export type Thing = ThingLeaf | Intangible;
 

--- a/packages/schema-dts-gen/test/baselines/simple_test.ts
+++ b/packages/schema-dts-gen/test/baselines/simple_test.ts
@@ -37,16 +37,16 @@ test(`baseline_${basename(import.meta.url)}`, async () => {
   expect(actual).toMatchInlineSnapshot(`
 "/** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
 export type WithContext<T extends Thing> = T & {
-    "@context": "https://schema.org";
+    "$context": "https://schema.org";
 };
 export interface Graph {
-    "@context": "https://schema.org";
-    "@graph": readonly Thing[];
+    "$context": "https://schema.org";
+    "$graph": readonly Thing[];
 }
 type SchemaValue<T> = T | readonly T[];
 type IdReference = {
     /** IRI identifying the canonical address of this object. */
-    "@id": string;
+    "$id": string;
 };
 type InputActionConstraints<T extends ActionBase> = Partial<{
     [K in Exclude<keyof T, \`@\${string}\`> as \`\${string & K}-input\`]: PropertyValueSpecification | string;
@@ -63,7 +63,7 @@ interface ThingBase extends Partial<IdReference> {
     "name"?: SchemaValue<Text>;
 }
 interface ThingLeaf extends ThingBase {
-    "@type": "Thing";
+    "$type": "Thing";
 }
 export type Thing = ThingLeaf;
 

--- a/packages/schema-dts-gen/test/baselines/sorted_enum_test.ts
+++ b/packages/schema-dts-gen/test/baselines/sorted_enum_test.ts
@@ -38,16 +38,16 @@ test(`baseline_${basename(import.meta.url)}`, async () => {
   expect(actual).toMatchInlineSnapshot(`
 "/** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
 export type WithContext<T extends Thing> = T & {
-    "@context": "https://schema.org";
+    "$context": "https://schema.org";
 };
 export interface Graph {
-    "@context": "https://schema.org";
-    "@graph": readonly Thing[];
+    "$context": "https://schema.org";
+    "$graph": readonly Thing[];
 }
 type SchemaValue<T> = T | readonly T[];
 type IdReference = {
     /** IRI identifying the canonical address of this object. */
-    "@id": string;
+    "$id": string;
 };
 type InputActionConstraints<T extends ActionBase> = Partial<{
     [K in Exclude<keyof T, \`@\${string}\`> as \`\${string & K}-input\`]: PropertyValueSpecification | string;
@@ -61,7 +61,7 @@ export type WithActionConstraints<T extends ActionBase> = T & InputActionConstra
 interface ThingBase extends Partial<IdReference> {
 }
 interface ThingLeaf extends ThingBase {
-    "@type": "Thing";
+    "$type": "Thing";
 }
 /** A Thing! */
 export type Thing = "http://schema.org/a" | "https://schema.org/a" | "a" | "http://schema.org/b" | "https://schema.org/b" | "b" | "http://schema.org/c" | "https://schema.org/c" | "c" | "http://schema.org/d" | "https://schema.org/d" | "d" | ThingLeaf;

--- a/packages/schema-dts-gen/test/baselines/sorted_props_test.ts
+++ b/packages/schema-dts-gen/test/baselines/sorted_props_test.ts
@@ -46,16 +46,16 @@ test(`baseline_${basename(import.meta.url)}`, async () => {
   expect(actual).toMatchInlineSnapshot(`
 "/** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
 export type WithContext<T extends Thing> = T & {
-    "@context": "https://schema.org";
+    "$context": "https://schema.org";
 };
 export interface Graph {
-    "@context": "https://schema.org";
-    "@graph": readonly Thing[];
+    "$context": "https://schema.org";
+    "$graph": readonly Thing[];
 }
 type SchemaValue<T> = T | readonly T[];
 type IdReference = {
     /** IRI identifying the canonical address of this object. */
-    "@id": string;
+    "$id": string;
 };
 type InputActionConstraints<T extends ActionBase> = Partial<{
     [K in Exclude<keyof T, \`@\${string}\`> as \`\${string & K}-input\`]: PropertyValueSpecification | string;
@@ -75,7 +75,7 @@ interface ThingBase extends Partial<IdReference> {
     "d"?: SchemaValue<Text>;
 }
 interface ThingLeaf extends ThingBase {
-    "@type": "Thing";
+    "$type": "Thing";
 }
 export type Thing = ThingLeaf;
 

--- a/packages/schema-dts-gen/test/baselines/sorted_proptypes_test.ts
+++ b/packages/schema-dts-gen/test/baselines/sorted_proptypes_test.ts
@@ -54,16 +54,16 @@ test(`baseline_${basename(import.meta.url)}`, async () => {
   expect(actual).toMatchInlineSnapshot(`
 "/** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
 export type WithContext<T extends Thing> = T & {
-    "@context": "https://schema.org";
+    "$context": "https://schema.org";
 };
 export interface Graph {
-    "@context": "https://schema.org";
-    "@graph": readonly Thing[];
+    "$context": "https://schema.org";
+    "$graph": readonly Thing[];
 }
 type SchemaValue<T> = T | readonly T[];
 type IdReference = {
     /** IRI identifying the canonical address of this object. */
-    "@id": string;
+    "$id": string;
 };
 type InputActionConstraints<T extends ActionBase> = Partial<{
     [K in Exclude<keyof T, \`@\${string}\`> as \`\${string & K}-input\`]: PropertyValueSpecification | string;
@@ -90,7 +90,7 @@ interface ThingBase extends Partial<IdReference> {
     "a"?: SchemaValue<Boolean | Date | DateTime | Number | Text | Time>;
 }
 interface ThingLeaf extends ThingBase {
-    "@type": "Thing";
+    "$type": "Thing";
 }
 export type Thing = ThingLeaf;
 

--- a/packages/schema-dts-gen/test/baselines/stringlike_http_test.ts
+++ b/packages/schema-dts-gen/test/baselines/stringlike_http_test.ts
@@ -62,16 +62,16 @@ test(`baseline_${basename(import.meta.url)}`, async () => {
   expect(actual).toMatchInlineSnapshot(`
 "/** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
 export type WithContext<T extends Thing> = T & {
-    "@context": "https://schema.org";
+    "$context": "https://schema.org";
 };
 export interface Graph {
-    "@context": "https://schema.org";
-    "@graph": readonly Thing[];
+    "$context": "https://schema.org";
+    "$graph": readonly Thing[];
 }
 type SchemaValue<T> = T | readonly T[];
 type IdReference = {
     /** IRI identifying the canonical address of this object. */
-    "@id": string;
+    "$id": string;
 };
 type InputActionConstraints<T extends ActionBase> = Partial<{
     [K in Exclude<keyof T, \`@\${string}\`> as \`\${string & K}-input\`]: PropertyValueSpecification | string;
@@ -85,7 +85,7 @@ export type WithActionConstraints<T extends ActionBase> = T & InputActionConstra
 export type Text = URL | string;
 
 interface EntryPointLeaf extends ThingBase {
-    "@type": "EntryPoint";
+    "$type": "EntryPoint";
 }
 export type EntryPoint = EntryPointLeaf | string;
 
@@ -95,7 +95,7 @@ interface OrganizationBase extends ThingBase {
     "urlTemplate"?: SchemaValue<URL>;
 }
 interface OrganizationLeaf extends OrganizationBase {
-    "@type": "Organization";
+    "$type": "Organization";
 }
 export type Organization = OrganizationLeaf | string;
 
@@ -104,17 +104,17 @@ interface PersonBase extends ThingBase {
     "locatedIn"?: SchemaValue<Place | IdReference>;
 }
 interface PersonLeaf extends PersonBase {
-    "@type": "Person";
+    "$type": "Person";
 }
 export type Person = PersonLeaf | string;
 
 interface PlaceLeaf extends ThingBase {
-    "@type": "Place";
+    "$type": "Place";
 }
 export type Place = PlaceLeaf | string;
 
 interface QuantityLeaf extends ThingBase {
-    "@type": "Quantity";
+    "$type": "Quantity";
 }
 export type Quantity = QuantityLeaf | string;
 
@@ -122,7 +122,7 @@ interface ThingBase extends Partial<IdReference> {
     "name"?: SchemaValue<Text>;
 }
 interface ThingLeaf extends ThingBase {
-    "@type": "Thing";
+    "$type": "Thing";
 }
 export type Thing = ThingLeaf | EntryPoint | Organization | Person | Place | Quantity;
 

--- a/packages/schema-dts-gen/test/baselines/stringlike_https_test.ts
+++ b/packages/schema-dts-gen/test/baselines/stringlike_https_test.ts
@@ -62,16 +62,16 @@ test(`baseline_${basename(import.meta.url)}`, async () => {
   expect(actual).toMatchInlineSnapshot(`
 "/** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
 export type WithContext<T extends Thing> = T & {
-    "@context": "https://schema.org";
+    "$context": "https://schema.org";
 };
 export interface Graph {
-    "@context": "https://schema.org";
-    "@graph": readonly Thing[];
+    "$context": "https://schema.org";
+    "$graph": readonly Thing[];
 }
 type SchemaValue<T> = T | readonly T[];
 type IdReference = {
     /** IRI identifying the canonical address of this object. */
-    "@id": string;
+    "$id": string;
 };
 type InputActionConstraints<T extends ActionBase> = Partial<{
     [K in Exclude<keyof T, \`@\${string}\`> as \`\${string & K}-input\`]: PropertyValueSpecification | string;
@@ -85,7 +85,7 @@ export type WithActionConstraints<T extends ActionBase> = T & InputActionConstra
 export type Text = URL | string;
 
 interface EntryPointLeaf extends ThingBase {
-    "@type": "EntryPoint";
+    "$type": "EntryPoint";
 }
 export type EntryPoint = EntryPointLeaf | string;
 
@@ -95,7 +95,7 @@ interface OrganizationBase extends ThingBase {
     "urlTemplate"?: SchemaValue<URL>;
 }
 interface OrganizationLeaf extends OrganizationBase {
-    "@type": "Organization";
+    "$type": "Organization";
 }
 export type Organization = OrganizationLeaf | string;
 
@@ -104,17 +104,17 @@ interface PersonBase extends ThingBase {
     "locatedIn"?: SchemaValue<Place | IdReference>;
 }
 interface PersonLeaf extends PersonBase {
-    "@type": "Person";
+    "$type": "Person";
 }
 export type Person = PersonLeaf | string;
 
 interface PlaceLeaf extends ThingBase {
-    "@type": "Place";
+    "$type": "Place";
 }
 export type Place = PlaceLeaf | string;
 
 interface QuantityLeaf extends ThingBase {
-    "@type": "Quantity";
+    "$type": "Quantity";
 }
 export type Quantity = QuantityLeaf | string;
 
@@ -122,7 +122,7 @@ interface ThingBase extends Partial<IdReference> {
     "name"?: SchemaValue<Text>;
 }
 interface ThingLeaf extends ThingBase {
-    "@type": "Thing";
+    "$type": "Thing";
 }
 export type Thing = ThingLeaf | EntryPoint | Organization | Person | Place | Quantity;
 

--- a/packages/schema-dts-gen/test/baselines/surgical_procedure_3_4_test.ts
+++ b/packages/schema-dts-gen/test/baselines/surgical_procedure_3_4_test.ts
@@ -51,16 +51,16 @@ test(`baseline_${basename(import.meta.url)}`, async () => {
   expect(actual).toMatchInlineSnapshot(`
 "/** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
 export type WithContext<T extends Thing> = T & {
-    "@context": "https://schema.org";
+    "$context": "https://schema.org";
 };
 export interface Graph {
-    "@context": "https://schema.org";
-    "@graph": readonly Thing[];
+    "$context": "https://schema.org";
+    "$graph": readonly Thing[];
 }
 type SchemaValue<T> = T | readonly T[];
 type IdReference = {
     /** IRI identifying the canonical address of this object. */
-    "@id": string;
+    "$id": string;
 };
 type InputActionConstraints<T extends ActionBase> = Partial<{
     [K in Exclude<keyof T, \`@\${string}\`> as \`\${string & K}-input\`]: PropertyValueSpecification | string;
@@ -72,32 +72,32 @@ type OutputActionConstraints<T extends ActionBase> = Partial<{
 export type WithActionConstraints<T extends ActionBase> = T & InputActionConstraints<T> & OutputActionConstraints<T>;
 
 interface EnumerationLeaf extends ThingBase {
-    "@type": "Enumeration";
+    "$type": "Enumeration";
 }
 export type Enumeration = EnumerationLeaf | MedicalEnumeration;
 
 interface IntangibleLeaf extends ThingBase {
-    "@type": "Intangible";
+    "$type": "Intangible";
 }
 export type Intangible = IntangibleLeaf | Enumeration;
 
 interface MedicalEnumerationLeaf extends ThingBase {
-    "@type": "MedicalEnumeration";
+    "$type": "MedicalEnumeration";
 }
 export type MedicalEnumeration = MedicalEnumerationLeaf | MedicalProcedureType;
 
 interface MedicalProcedureLeaf extends ThingBase {
-    "@type": "MedicalProcedure";
+    "$type": "MedicalProcedure";
 }
 export type MedicalProcedure = MedicalProcedureLeaf | SurgicalProcedure;
 
 interface MedicalProcedureTypeLeaf extends ThingBase {
-    "@type": "MedicalProcedureType";
+    "$type": "MedicalProcedureType";
 }
 export type MedicalProcedureType = "http://schema.org/SurgicalProcedure" | "https://schema.org/SurgicalProcedure" | "SurgicalProcedure" | MedicalProcedureTypeLeaf;
 
 interface SurgicalProcedureLeaf extends ThingBase {
-    "@type": "SurgicalProcedure";
+    "$type": "SurgicalProcedure";
 }
 /** A type of medical procedure that involves invasive surgical techniques. */
 export type SurgicalProcedure = SurgicalProcedureLeaf;
@@ -105,7 +105,7 @@ export type SurgicalProcedure = SurgicalProcedureLeaf;
 interface ThingBase extends Partial<IdReference> {
 }
 interface ThingLeaf extends ThingBase {
-    "@type": "Thing";
+    "$type": "Thing";
 }
 export type Thing = ThingLeaf | Intangible | MedicalProcedure;
 

--- a/packages/schema-dts-gen/test/baselines/surgical_procedure_3_4_v2_test.ts
+++ b/packages/schema-dts-gen/test/baselines/surgical_procedure_3_4_v2_test.ts
@@ -51,16 +51,16 @@ test(`baseline_${basename(import.meta.url)}`, async () => {
   expect(actual).toMatchInlineSnapshot(`
 "/** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
 export type WithContext<T extends Thing> = T & {
-    "@context": "https://schema.org";
+    "$context": "https://schema.org";
 };
 export interface Graph {
-    "@context": "https://schema.org";
-    "@graph": readonly Thing[];
+    "$context": "https://schema.org";
+    "$graph": readonly Thing[];
 }
 type SchemaValue<T> = T | readonly T[];
 type IdReference = {
     /** IRI identifying the canonical address of this object. */
-    "@id": string;
+    "$id": string;
 };
 type InputActionConstraints<T extends ActionBase> = Partial<{
     [K in Exclude<keyof T, \`@\${string}\`> as \`\${string & K}-input\`]: PropertyValueSpecification | string;
@@ -72,32 +72,32 @@ type OutputActionConstraints<T extends ActionBase> = Partial<{
 export type WithActionConstraints<T extends ActionBase> = T & InputActionConstraints<T> & OutputActionConstraints<T>;
 
 interface EnumerationLeaf extends ThingBase {
-    "@type": "Enumeration";
+    "$type": "Enumeration";
 }
 export type Enumeration = EnumerationLeaf | MedicalEnumeration;
 
 interface IntangibleLeaf extends ThingBase {
-    "@type": "Intangible";
+    "$type": "Intangible";
 }
 export type Intangible = IntangibleLeaf | Enumeration;
 
 interface MedicalEnumerationLeaf extends ThingBase {
-    "@type": "MedicalEnumeration";
+    "$type": "MedicalEnumeration";
 }
 export type MedicalEnumeration = MedicalEnumerationLeaf | MedicalProcedureType;
 
 interface MedicalProcedureLeaf extends ThingBase {
-    "@type": "MedicalProcedure";
+    "$type": "MedicalProcedure";
 }
 export type MedicalProcedure = MedicalProcedureLeaf | SurgicalProcedure;
 
 interface MedicalProcedureTypeLeaf extends ThingBase {
-    "@type": "MedicalProcedureType";
+    "$type": "MedicalProcedureType";
 }
 export type MedicalProcedureType = "http://schema.org/SurgicalProcedure" | "https://schema.org/SurgicalProcedure" | "SurgicalProcedure" | MedicalProcedureTypeLeaf;
 
 interface SurgicalProcedureLeaf extends ThingBase {
-    "@type": "SurgicalProcedure";
+    "$type": "SurgicalProcedure";
 }
 /** A type of medical procedure that involves invasive surgical techniques. */
 export type SurgicalProcedure = SurgicalProcedureLeaf;
@@ -105,7 +105,7 @@ export type SurgicalProcedure = SurgicalProcedureLeaf;
 interface ThingBase extends Partial<IdReference> {
 }
 interface ThingLeaf extends ThingBase {
-    "@type": "Thing";
+    "$type": "Thing";
 }
 export type Thing = ThingLeaf | Intangible | MedicalProcedure;
 

--- a/packages/schema-dts-gen/test/baselines/surgical_procedure_test.ts
+++ b/packages/schema-dts-gen/test/baselines/surgical_procedure_test.ts
@@ -76,16 +76,16 @@ test(`baseline_${basename(import.meta.url)}`, async () => {
   expect(actual).toMatchInlineSnapshot(`
 "/** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
 export type WithContext<T extends Thing> = T & {
-    "@context": "https://schema.org";
+    "$context": "https://schema.org";
 };
 export interface Graph {
-    "@context": "https://schema.org";
-    "@graph": readonly Thing[];
+    "$context": "https://schema.org";
+    "$graph": readonly Thing[];
 }
 type SchemaValue<T> = T | readonly T[];
 type IdReference = {
     /** IRI identifying the canonical address of this object. */
-    "@id": string;
+    "$id": string;
 };
 type InputActionConstraints<T extends ActionBase> = Partial<{
     [K in Exclude<keyof T, \`@\${string}\`> as \`\${string & K}-input\`]: PropertyValueSpecification | string;
@@ -97,69 +97,69 @@ type OutputActionConstraints<T extends ActionBase> = Partial<{
 export type WithActionConstraints<T extends ActionBase> = T & InputActionConstraints<T> & OutputActionConstraints<T>;
 
 interface DiagnosticProcedureLeaf extends ThingBase {
-    "@type": "DiagnosticProcedure";
+    "$type": "DiagnosticProcedure";
 }
 export type DiagnosticProcedure = DiagnosticProcedureLeaf;
 
 interface EnumerationLeaf extends ThingBase {
-    "@type": "Enumeration";
+    "$type": "Enumeration";
 }
 export type Enumeration = EnumerationLeaf | MedicalEnumeration;
 
 interface IntangibleLeaf extends ThingBase {
-    "@type": "Intangible";
+    "$type": "Intangible";
 }
 export type Intangible = IntangibleLeaf | Enumeration;
 
 interface MedicalEntityLeaf extends ThingBase {
-    "@type": "MedicalEntity";
+    "$type": "MedicalEntity";
 }
 export type MedicalEntity = MedicalEntityLeaf | MedicalProcedure;
 
 interface MedicalEnumerationLeaf extends ThingBase {
-    "@type": "MedicalEnumeration";
+    "$type": "MedicalEnumeration";
 }
 export type MedicalEnumeration = MedicalEnumerationLeaf | MedicalProcedureType | PhysicalExam;
 
 interface MedicalProcedureLeaf extends ThingBase {
-    "@type": "MedicalProcedure";
+    "$type": "MedicalProcedure";
 }
 /** A process of care used in either a diagnostic, therapeutic, preventive or palliative capacity that relies on invasive (surgical), non-invasive, or other techniques. */
 export type MedicalProcedure = MedicalProcedureLeaf | DiagnosticProcedure | PalliativeProcedure | PhysicalExam | SurgicalProcedure | TherapeuticProcedure;
 
 interface MedicalProcedureTypeLeaf extends ThingBase {
-    "@type": "MedicalProcedureType";
+    "$type": "MedicalProcedureType";
 }
 /** An enumeration that describes different types of medical procedures. */
 export type MedicalProcedureType = "http://schema.org/NoninvasiveProcedure" | "https://schema.org/NoninvasiveProcedure" | "NoninvasiveProcedure" | "http://schema.org/PercutaneousProcedure" | "https://schema.org/PercutaneousProcedure" | "PercutaneousProcedure" | MedicalProcedureTypeLeaf;
 
 interface MedicalTherapyLeaf extends ThingBase {
-    "@type": "MedicalTherapy";
+    "$type": "MedicalTherapy";
 }
 export type MedicalTherapy = MedicalTherapyLeaf | PalliativeProcedure;
 
 interface PalliativeProcedureBase extends ThingBase, ThingBase {
 }
 interface PalliativeProcedureLeaf extends PalliativeProcedureBase {
-    "@type": "PalliativeProcedure";
+    "$type": "PalliativeProcedure";
 }
 export type PalliativeProcedure = PalliativeProcedureLeaf;
 
 interface PhysicalExamBase extends ThingBase, ThingBase {
 }
 interface PhysicalExamLeaf extends PhysicalExamBase {
-    "@type": "PhysicalExam";
+    "$type": "PhysicalExam";
 }
 export type PhysicalExam = "http://schema.org/Head" | "https://schema.org/Head" | "Head" | "http://schema.org/Neuro" | "https://schema.org/Neuro" | "Neuro" | PhysicalExamLeaf;
 
 interface SurgicalProcedureLeaf extends ThingBase {
-    "@type": "SurgicalProcedure";
+    "$type": "SurgicalProcedure";
 }
 /** A medical procedure involving an incision with instruments; performed for diagnose, or therapeutic purposes. */
 export type SurgicalProcedure = SurgicalProcedureLeaf;
 
 interface TherapeuticProcedureLeaf extends ThingBase {
-    "@type": "TherapeuticProcedure";
+    "$type": "TherapeuticProcedure";
 }
 export type TherapeuticProcedure = TherapeuticProcedureLeaf | MedicalTherapy;
 
@@ -167,7 +167,7 @@ interface ThingBase extends Partial<IdReference> {
     "procedureType"?: SchemaValue<MedicalProcedureType | IdReference>;
 }
 interface ThingLeaf extends ThingBase {
-    "@type": "Thing";
+    "$type": "Thing";
 }
 export type Thing = ThingLeaf | Intangible | MedicalEntity;
 

--- a/packages/schema-dts-gen/test/baselines/transitive_class_test.ts
+++ b/packages/schema-dts-gen/test/baselines/transitive_class_test.ts
@@ -41,16 +41,16 @@ test(`baseline_${basename(import.meta.url)}`, async () => {
   expect(actual).toMatchInlineSnapshot(`
 "/** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
 export type WithContext<T extends Thing> = T & {
-    "@context": "https://schema.org";
+    "$context": "https://schema.org";
 };
 export interface Graph {
-    "@context": "https://schema.org";
-    "@graph": readonly Thing[];
+    "$context": "https://schema.org";
+    "$graph": readonly Thing[];
 }
 type SchemaValue<T> = T | readonly T[];
 type IdReference = {
     /** IRI identifying the canonical address of this object. */
-    "@id": string;
+    "$id": string;
 };
 type InputActionConstraints<T extends ActionBase> = Partial<{
     [K in Exclude<keyof T, \`@\${string}\`> as \`\${string & K}-input\`]: PropertyValueSpecification | string;
@@ -65,7 +65,7 @@ export type WithActionConstraints<T extends ActionBase> = T & InputActionConstra
 export type Text = string;
 
 interface PersonLeaf extends ThingBase {
-    "@type": "Person";
+    "$type": "Person";
 }
 /** ABC */
 export type Person = PersonLeaf | string;
@@ -74,7 +74,7 @@ interface ThingBase extends Partial<IdReference> {
     "name"?: SchemaValue<Text>;
 }
 interface ThingLeaf extends ThingBase {
-    "@type": "Thing";
+    "$type": "Thing";
 }
 /** ABC */
 export type Thing = ThingLeaf | Person;

--- a/packages/schema-dts-gen/test/baselines/url_test.ts
+++ b/packages/schema-dts-gen/test/baselines/url_test.ts
@@ -37,16 +37,16 @@ test(`baseline_${basename(import.meta.url)}`, async () => {
   expect(actual).toMatchInlineSnapshot(`
 "/** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
 export type WithContext<T extends Thing> = T & {
-    "@context": "https://schema.org";
+    "$context": "https://schema.org";
 };
 export interface Graph {
-    "@context": "https://schema.org";
-    "@graph": readonly Thing[];
+    "$context": "https://schema.org";
+    "$graph": readonly Thing[];
 }
 type SchemaValue<T> = T | readonly T[];
 type IdReference = {
     /** IRI identifying the canonical address of this object. */
-    "@id": string;
+    "$id": string;
 };
 type InputActionConstraints<T extends ActionBase> = Partial<{
     [K in Exclude<keyof T, \`@\${string}\`> as \`\${string & K}-input\`]: PropertyValueSpecification | string;

--- a/packages/schema-dts-gen/test/ts/class_test.ts
+++ b/packages/schema-dts-gen/test/ts/class_test.ts
@@ -71,13 +71,13 @@ describe('Class', () => {
       const ctx = new Context();
       ctx.setUrlContext('https://schema.org/');
       expect(asString(cls, ctx)).toMatchInlineSnapshot(`
-        "interface PersonBase extends Partial<IdReference> {
-        }
-        interface PersonLeaf extends PersonBase {
-            "@type": "Person";
-        }
-        export type Person = PersonLeaf;"
-      `);
+"interface PersonBase extends Partial<IdReference> {
+}
+interface PersonLeaf extends PersonBase {
+    "$type": "Person";
+}
+export type Person = PersonLeaf;"
+`);
     });
 
     it('empty (with parent)', () => {
@@ -86,11 +86,11 @@ describe('Class', () => {
       addParent(cls, 'https://schema.org/Thing');
 
       expect(asString(cls, ctx)).toMatchInlineSnapshot(`
-        "interface PersonLeaf extends ThingBase {
-            "@type": "Person";
-        }
-        export type Person = PersonLeaf;"
-      `);
+"interface PersonLeaf extends ThingBase {
+    "$type": "Person";
+}
+export type Person = PersonLeaf;"
+`);
     });
 
     it('empty (two parents)', () => {
@@ -100,13 +100,13 @@ describe('Class', () => {
       addParent(cls, 'https://schema.org/Thing2');
 
       expect(asString(cls, ctx)).toMatchInlineSnapshot(`
-        "interface PersonBase extends Thing1Base, Thing2Base {
-        }
-        interface PersonLeaf extends PersonBase {
-            "@type": "Person";
-        }
-        export type Person = PersonLeaf;"
-      `);
+"interface PersonBase extends Thing1Base, Thing2Base {
+}
+interface PersonLeaf extends PersonBase {
+    "$type": "Person";
+}
+export type Person = PersonLeaf;"
+`);
     });
 
     it('deprecated once (only)', () => {
@@ -126,12 +126,12 @@ describe('Class', () => {
       ).toBe(true);
 
       expect(asString(cls, ctx)).toMatchInlineSnapshot(`
-        "interface PersonLeaf extends ThingBase {
-            "@type": "Person";
-        }
-        /** @deprecated Use CoolPerson instead. */
-        export type Person = PersonLeaf;"
-      `);
+"interface PersonLeaf extends ThingBase {
+    "$type": "Person";
+}
+/** @deprecated Use CoolPerson instead. */
+export type Person = PersonLeaf;"
+`);
     });
 
     it('deprecated twice (alphabetical)', () => {
@@ -168,12 +168,12 @@ describe('Class', () => {
       ).toBe(true);
 
       expect(asString(cls, ctx)).toMatchInlineSnapshot(`
-        "interface PersonLeaf extends ThingBase {
-            "@type": "Person";
-        }
-        /** @deprecated Use APerson or CoolPerson instead. */
-        export type Person = PersonLeaf;"
-      `);
+"interface PersonLeaf extends ThingBase {
+    "$type": "Person";
+}
+/** @deprecated Use APerson or CoolPerson instead. */
+export type Person = PersonLeaf;"
+`);
     });
 
     it('deprecated with comment', () => {
@@ -199,16 +199,16 @@ describe('Class', () => {
       ).toBe(true);
 
       expect(asString(cls, ctx)).toMatchInlineSnapshot(`
-        "interface PersonLeaf extends ThingBase {
-            "@type": "Person";
-        }
-        /**
-         * Fantastic
-         *
-         * @deprecated Use CoolPerson instead.
-         */
-        export type Person = PersonLeaf;"
-      `);
+"interface PersonLeaf extends ThingBase {
+    "$type": "Person";
+}
+/**
+ * Fantastic
+ *
+ * @deprecated Use CoolPerson instead.
+ */
+export type Person = PersonLeaf;"
+`);
     });
 
     it('complains about bad comment markup', () => {
@@ -253,19 +253,19 @@ describe('Class', () => {
       cls.addProp(makeProperty('https://abc.com'));
 
       expect(asString(cls, ctx)).toMatchInlineSnapshot(`
-        "interface ABase extends Partial<IdReference> {
-            "https://abc.com"?: SchemaValue<never>;
-            "schema:"?: SchemaValue<never>;
-            "schema:a"?: SchemaValue<never>;
-            "schema:b"?: SchemaValue<never>;
-            "schema:c"?: SchemaValue<never>;
-            "https://abc.com/e"?: SchemaValue<never>;
-        }
-        interface ALeaf extends ABase {
-            "@type": "schema:A";
-        }
-        export type A = ALeaf;"
-      `);
+"interface ABase extends Partial<IdReference> {
+    "https://abc.com"?: SchemaValue<never>;
+    "schema:"?: SchemaValue<never>;
+    "schema:a"?: SchemaValue<never>;
+    "schema:b"?: SchemaValue<never>;
+    "schema:c"?: SchemaValue<never>;
+    "https://abc.com/e"?: SchemaValue<never>;
+}
+interface ALeaf extends ABase {
+    "$type": "schema:A";
+}
+export type A = ALeaf;"
+`);
     });
   });
 });

--- a/packages/schema-dts-gen/test/ts/context_test.ts
+++ b/packages/schema-dts-gen/test/ts/context_test.ts
@@ -37,7 +37,7 @@ describe('WithContext generation', () => {
     ctx.setUrlContext('https://foo.com');
 
     expect(asString(ctx.contextProperty())).toBe(
-      `"@context": "https://foo.com";`,
+      `"$context": "https://foo.com";`,
     );
   });
 
@@ -47,7 +47,7 @@ describe('WithContext generation', () => {
     ctx.addNamedContext('b', 'https://bar.com');
 
     expect(asString(ctx.contextProperty())).toBe(
-      `"@context": {
+      `"$context": {
     "a": "https://foo.com";
     "b": "https://bar.com";
 };`,

--- a/packages/schema-dts/README.md
+++ b/packages/schema-dts/README.md
@@ -34,7 +34,7 @@ Then you can use it by importing `"schema-dts"`.
 import type {Person} from 'schema-dts';
 
 const inventor: Person = {
-  '@type': 'Person',
+  $type: 'Person',
   name: 'Grace Hopper',
   disambiguatingDescription: 'American computer scientist',
   birthDate: '1906-12-09',
@@ -49,7 +49,7 @@ const inventor: Person = {
 
 ### Using 'Context'
 
-JSON-LD requires a `"@context"` property to be set on the top-level JSON object,
+JSON-LD requires a `"$context"` property to be set on the top-level JSON object,
 to describe the URIs represeting the types and properties being referenced.
 schema-dts provides the `WithContext<T>` type to facilitate this.
 
@@ -63,67 +63,67 @@ ${JSON.stringify(json)}
 }
 
 export const MY_ORG = JsonLd<Organization>({
-  '@context': 'https://schema.org',
-  '@type': 'Corporation',
+  $context: 'https://schema.org',
+  $type: 'Corporation',
   name: 'Google LLC',
 });
 ```
 
 ### Graphs and IDs
 
-JSON-LD supports `'@graph'` objects that have richer interconnected links
+JSON-LD supports `'$graph'` objects that have richer interconnected links
 between the nodes. You can do that easily in `schema-dts` by using the `Graph`
 type.
 
-Notice that any node can have an `@id` when defining it. And you can reference
+Notice that any node can have an `$id` when defining it. And you can reference
 the same node from different places by simply using an ID stub, for example
-`{ '@id': 'https://my.site/about/#page }` below is an ID stub.
+`{ '$id': 'https://my.site/about/#page }` below is an ID stub.
 
 The example below shows potential JSON-LD for an About page. It includes
 definitions of Alyssa P. Hacker (the author & subject of the page), the specific
 page in this URL, and the website it belongs to. Some objects are still defined
 as inline nested objects (e.g. Occupation), since they are only referenced by
-their parent. Other objects are defined at the top-level with an `@id`, because
+their parent. Other objects are defined at the top-level with an `$id`, because
 multiple nodes refer to them.
 
 ```ts
 import type {Graph} from 'schema-dts';
 
 const graph: Graph = {
-  '@context': 'https://schema.org',
-  '@graph': [
+  $context: 'https://schema.org',
+  $graph: [
     {
-      '@type': 'Person',
-      '@id': 'https://my.site/#alyssa',
+      $type: 'Person',
+      $id: 'https://my.site/#alyssa',
       name: 'Alyssa P. Hacker',
       hasOccupation: {
-        '@type': 'Occupation',
+        $type: 'Occupation',
         name: 'LISP Hacker',
         qualifications: 'Knows LISP',
       },
-      mainEntityOfPage: {'@id': 'https://my.site/about/#page'},
-      subjectOf: {'@id': 'https://my.site/about/#page'},
+      mainEntityOfPage: {$id: 'https://my.site/about/#page'},
+      subjectOf: {$id: 'https://my.site/about/#page'},
     },
     {
-      '@type': 'AboutPage',
-      '@id': 'https://my.site/#site',
+      $type: 'AboutPage',
+      $id: 'https://my.site/#site',
       url: 'https://my.site',
       name: "Alyssa P. Hacker's Website",
       inLanguage: 'en-US',
       description: 'The personal website of LISP legend Alyssa P. Hacker',
-      mainEntity: {'@id': 'https://my.site/#alyssa'},
+      mainEntity: {$id: 'https://my.site/#alyssa'},
     },
     {
-      '@type': 'WebPage',
-      '@id': 'https://my.site/about/#page',
+      $type: 'WebPage',
+      $id: 'https://my.site/about/#page',
       url: 'https://my.site/about/',
       name: "About | Alyssa P. Hacker's Website",
       inLanguage: 'en-US',
       isPartOf: {
-        '@id': 'https://my.site/#site',
+        $id: 'https://my.site/#site',
       },
-      about: {'@id': 'https://my.site/#alyssa'},
-      mainEntity: {'@id': 'https://my.site/#alyssa'},
+      about: {$id: 'https://my.site/#alyssa'},
+      mainEntity: {$id: 'https://my.site/#alyssa'},
     },
   ],
 };

--- a/packages/schema-dts/test/easy.ts
+++ b/packages/schema-dts/test/easy.ts
@@ -1,36 +1,36 @@
 import {Thing} from '../dist/schema';
 
-// "@type" is required
-// @ts-expect-error missing @type
+// "$type" is required
+// @ts-expect-error missing $type
 const _1: Thing = {};
 
-// "@type" can be the requested tpye
+// "$type" can be the requested tpye
 const _2: Thing = {
-  '@type': 'Thing',
+  $type: 'Thing',
 };
 
-// "@type" can be a sub-type
+// "$type" can be a sub-type
 const _3: Thing = {
-  '@type': 'Person',
+  $type: 'Person',
 };
 
-// "@type" must be valid
+// "$type" must be valid
 const _4: Thing = {
   // @ts-expect-error Invalid type
-  '@type': 'Personz',
+  $type: 'Personz',
 };
 
-// A narrow "@type" allows defining sub-properties
+// A narrow "$type" allows defining sub-properties
 const _5: Thing = {
-  '@type': 'Person',
+  $type: 'Person',
   name: 'a',
   additionalName: ['b', 'c', 'd'],
 };
 
-// A wide "@type" disallows valid sub-properties
+// A wide "$type" disallows valid sub-properties
 // (when excess property checking is on)
 const _6: Thing = {
-  '@type': 'Thing',
+  $type: 'Thing',
   name: 'a',
   // @ts-expect-error Thing too broad for additionalName
   additionalName: ['b', 'c', 'd'],

--- a/packages/schema-dts/test/graph.ts
+++ b/packages/schema-dts/test/graph.ts
@@ -1,51 +1,51 @@
 import {Graph} from '../dist/schema';
 
-// "@context" and "@graph" are both required
-// @ts-expect-error Missing @graph and @context
+// "$context" and "$graph" are both required
+// @ts-expect-error Missing $graph and $context
 const _1: Graph = {};
 
-// @ts-expect-error Missing @context
-const _2: Graph = {'@graph': []};
+// @ts-expect-error Missing $context
+const _2: Graph = {$graph: []};
 
-// @ts-expect-error Missing @graph
-const _3: Graph = {'@context': 'https://schema.org'};
+// @ts-expect-error Missing $graph
+const _3: Graph = {$context: 'https://schema.org'};
 
 const _4: Graph = {
-  '@context': 'https://schema.org',
-  '@graph': [],
+  $context: 'https://schema.org',
+  $graph: [],
 };
 
-// "@context" must be correct.
+// "$context" must be correct.
 const _5: Graph = {
   // @ts-expect-error Incorrect context
-  '@context': 'https://google.com',
-  '@graph': [],
+  $context: 'https://google.com',
+  $graph: [],
 };
 
-// "@graph" can have full objects, and types
+// "$graph" can have full objects, and types
 const _6: Graph = {
-  '@context': 'https://schema.org',
-  '@graph': [
-    {'@type': 'Thing'},
-    {'@type': 'Thing', '@id': 'X'},
-    {'@type': 'Person', knowsAbout: {'@id': 'X'}},
+  $context: 'https://schema.org',
+  $graph: [
+    {$type: 'Thing'},
+    {$type: 'Thing', $id: 'X'},
+    {$type: 'Person', knowsAbout: {$id: 'X'}},
   ],
 };
 
-// "@graph" still type-checks
+// "$graph" still type-checks
 const _7: Graph = {
-  '@context': 'https://schema.org',
-  '@graph': [
+  $context: 'https://schema.org',
+  $graph: [
     {
-      '@type': 'Thing',
+      $type: 'Thing',
       // @ts-expect-error Unknown property
       g: 5,
     },
     {
       // @ts-expect-error Invalid type
-      '@type': 'Thingz',
-      '@id': 'X',
+      $type: 'Thingz',
+      $id: 'X',
     },
-    {'@type': 'Person', knowsAbout: {'@id': 'X'}},
+    {$type: 'Person', knowsAbout: {$id: 'X'}},
   ],
 };

--- a/packages/schema-dts/test/values.ts
+++ b/packages/schema-dts/test/values.ts
@@ -2,18 +2,18 @@ import {Thing} from '../dist/schema';
 
 // Strings & Roles work
 const _1: Thing = {
-  '@type': 'Person',
+  $type: 'Person',
   knowsAbout: [
-    {'@id': 'A'},
+    {$id: 'A'},
     'B',
-    {'@type': 'Role', knowsAbout: {'@id': 'A'}, roleName: 'abc'},
-    {'@type': 'Role', knowsAbout: 'B', roleName: 'bce'},
+    {$type: 'Role', knowsAbout: {$id: 'A'}, roleName: 'abc'},
+    {$type: 'Role', knowsAbout: 'B', roleName: 'bce'},
   ],
 };
 
 // Numbers work
 const _2: Thing = {
-  '@type': 'Accommodation',
+  $type: 'Accommodation',
   numberOfBedrooms: 5,
   numberOfBathroomsTotal: '6',
   numberOfFullBathrooms: '555.3',
@@ -21,22 +21,22 @@ const _2: Thing = {
 
 // Numbers work in Roles
 const _3: Thing = {
-  '@type': 'Accommodation',
-  numberOfBedrooms: {'@type': 'Role', numberOfBedrooms: 5},
-  numberOfBathroomsTotal: {'@type': 'Role', numberOfBathroomsTotal: '6'},
-  numberOfFullBathrooms: {'@type': 'Role', numberOfFullBathrooms: '555.3'},
+  $type: 'Accommodation',
+  numberOfBedrooms: {$type: 'Role', numberOfBedrooms: 5},
+  numberOfBathroomsTotal: {$type: 'Role', numberOfBathroomsTotal: '6'},
+  numberOfFullBathrooms: {$type: 'Role', numberOfFullBathrooms: '555.3'},
 };
 
 // Numbers work in strings
 const _4: Thing = {
-  '@type': 'Accommodation',
+  $type: 'Accommodation',
   numberOfBedrooms: [5, '6', '555'],
   numberOfBathroomsTotal: ['6'],
 };
 
 // Numbers must be valid
 const _5: Thing = {
-  '@type': 'Accommodation',
+  $type: 'Accommodation',
   numberOfBedrooms: [
     5,
     // @ts-expect-error Invalid number
@@ -51,13 +51,13 @@ const _5: Thing = {
 
 // Roles must be valid
 const _6: Thing = {
-  '@type': 'Person',
+  $type: 'Person',
   knowsAbout: [
     // @ts-expect-error Invalid role
-    {'@type': 'Role', knowsAbourt: {'@id': 'A'}, roleName: 'abc'},
+    {$type: 'Role', knowsAbourt: {$id: 'A'}, roleName: 'abc'},
     // @ts-expect-error Invalid role
     {
-      '@type': 'Role',
+      $type: 'Role',
       knowsAbout: {},
       roleName: 'bce',
     },

--- a/packages/schema-dts/test/withactionconstraints.ts
+++ b/packages/schema-dts/test/withactionconstraints.ts
@@ -1,29 +1,29 @@
 import {SearchAction, WebSite, WithActionConstraints} from '../dist/schema';
 
-// @ts-expect-error Missing '@type'
+// @ts-expect-error Missing '$type'
 const _1: WithActionConstraints<SearchAction> = {};
 
 const _2: SearchAction = {
-  '@type': 'SearchAction',
+  $type: 'SearchAction',
   // @ts-expect-error 'query-input' is not defined
   'query-input': 'required name=search_term_string',
 };
 
 const _3: WithActionConstraints<SearchAction> = {
-  '@type': 'SearchAction',
+  $type: 'SearchAction',
   'query-input': 'required name=search_term_string',
 };
 
 const _4: WithActionConstraints<SearchAction> = {
-  '@type': 'SearchAction',
+  $type: 'SearchAction',
   // @ts-expect-error 'query-inputs' is not defined
   'query-inputs': 'required name=search_term_string',
 };
 
 const _5: WebSite = {
-  '@type': 'WebSite',
+  $type: 'WebSite',
   potentialAction: {
-    '@type': 'SearchAction',
+    $type: 'SearchAction',
     'query-input': 'required name=search_term_string',
   } as WithActionConstraints<SearchAction>,
 };

--- a/packages/schema-dts/test/withcontext.ts
+++ b/packages/schema-dts/test/withcontext.ts
@@ -1,23 +1,23 @@
 import {Thing, WithContext} from '../dist/schema';
 
-// "@context" and "@type" are both required
-// @ts-expect-error Missing '@type' and '@contet.'
+// "$context" and "$type" are both required
+// @ts-expect-error Missing '$type' and '$contet.'
 const _1: WithContext<Thing> = {};
 
-// @ts-expect-error Missing '@context'
-const _2: WithContext<Thing> = {'@type': 'Thing'};
+// @ts-expect-error Missing '$context'
+const _2: WithContext<Thing> = {$type: 'Thing'};
 
-// @ts-expect-error Missing '@type'
-const _3: WithContext<Thing> = {'@context': 'https://schema.org'};
+// @ts-expect-error Missing '$type'
+const _3: WithContext<Thing> = {$context: 'https://schema.org'};
 
 const _4: WithContext<Thing> = {
-  '@context': 'https://schema.org',
-  '@type': 'Thing',
+  $context: 'https://schema.org',
+  $type: 'Thing',
 };
 
-// "@context" must be correct.
+// "$context" must be correct.
 const _5: WithContext<Thing> = {
   // @ts-expect-error Must be schema.org
-  '@context': 'https://google.com',
-  '@type': 'Thing',
+  $context: 'https://google.com',
+  $type: 'Thing',
 };


### PR DESCRIPTION
# Replace @ Prefix with $ for JSON-LD Properties

## Overview
This PR replaces all instances of the `@` prefix with `$` on properties like `$id`, `$type`, `$context`, and `$graph` throughout the codebase to support YAML-LD and JSON-LD convenience approaches. This change makes TypeScript/JavaScript development easier as `$` is valid in variable names while `@` is not.

## Changes
- Updated core type definitions in:
  - `packages/schema-dts-gen/src/ts/helper_types.ts`: Replaced `@id` with `$id` and `@graph` with `$graph`
  - `packages/schema-dts-gen/src/ts/property.ts`: Replaced `@type` with `$type`
  - `packages/schema-dts-gen/src/ts/context.ts`: Replaced `@context` with `$context`
  - `packages/schema-dts-gen/src/ts/class.ts`: Updated comments
- Updated test files:
  - `packages/schema-dts/test/graph.ts`
  - `packages/schema-dts/test/withcontext.ts`
  - `packages/schema-dts/test/withactionconstraints.ts`
  - `packages/schema-dts/test/values.ts`
  - `packages/schema-dts/test/easy.ts`
- Updated documentation in:
  - `packages/schema-dts/README.md`
  - `README.md`
- Updated test snapshots to match the new output

## Testing
All tests are passing with the new `$` prefix.

## Link to Devin run
https://app.devin.ai/sessions/ddd33a2a92e54e4f9a210a7d7e252704

## Requested by
Nathan Clevenger (nateclev@gmail.com)
